### PR TITLE
Bug/no context for beforeeach in describe

### DIFF
--- a/Tester.js
+++ b/Tester.js
@@ -33,12 +33,14 @@ module.exports = function(logger) {
 	}
 
 	function describe(name, functionContainingTests) {
+		var previousBeforeEach = beforeEachFunction;
 		log(' ');
 		log(name.bold);
 		addPrefixeSize(2);
 		functionContainingTests();
 		addPrefixeSize(-2);
 		log(' ');
+		beforeEachFunction = previousBeforeEach;
 	}
 
 	return {

--- a/Tester.js
+++ b/Tester.js
@@ -5,7 +5,11 @@ module.exports = function(logger) {
 	var prefixe = '';
 
 	function beforeEach(functionToRun) {
-		beforeEachFunction = functionToRun;
+		var previousBeforeEach = beforeEachFunction;
+		beforeEachFunction = function() {
+			previousBeforeEach();
+			functionToRun();
+		};
 	}
 
 	function addPrefixeSize(value) {

--- a/TesterSpec.js
+++ b/TesterSpec.js
@@ -211,3 +211,23 @@ testThat('describe should add some space for the logger', function() {
 
 	assertThat(logger.logged('  some test' + ' passed!'.green), isTrue);
 });
+
+testThat('describe should reset the beforeEach function after it is done', function() {
+	var steps = '';
+
+	tester.beforeEach(function() {
+		steps += 'a';
+	});
+
+	tester.testThat('', function() {});
+
+	tester.describe('b', function() {
+		tester.beforeEach(function() {
+			steps += 'b';
+		});
+	});
+
+	tester.testThat('', function() {});
+
+	assertThat(steps, equals('aa'));
+});

--- a/TesterSpec.js
+++ b/TesterSpec.js
@@ -231,3 +231,25 @@ testThat('describe should reset the beforeEach function after it is done', funct
 
 	assertThat(steps, equals('aa'));
 });
+
+testThat('describe should call the previous beforeEach function before its own', function() {
+	var steps = '';
+
+	tester.beforeEach(function() {
+		steps += 'a';
+	});
+
+	tester.testThat('', function() {});
+
+	tester.describe('b', function() {
+		tester.beforeEach(function() {
+			steps += 'b';
+		});
+
+		tester.testThat('', function() {});
+	});
+
+	tester.testThat('', function() {});
+
+	assertThat(steps, equals('aaba'));
+});


### PR DESCRIPTION
Fixed the context bugs of the `describe`function.
It now reset the previous `beforeEach` function after its completion and calls the previous `beforeEach`function before its own.
